### PR TITLE
allow update to existing entries in Firebase

### DIFF
--- a/app/controllers/api/v1/gh_payloads_controller.rb
+++ b/app/controllers/api/v1/gh_payloads_controller.rb
@@ -7,7 +7,13 @@ class Api::V1::GhPayloadsController < ApplicationController
 
     firebase = Firebase::Client.new(ENV['FIREBASE_URL'])
     if request.env['HTTP_X_GITHUB_EVENT'] == 'pull_request'
-      firebase.push('gh_events', Firebase::Github::PullRequestSerializer.new(push).params)
+      serialized_params = Firebase::Github::PullRequestSerializer.new(push).params
+      existing_event = firebase.get('gh_events', id: serializer_params[:id])
+      if existing_event.present?
+        firebase.update('gh_events', serialized_params)
+      else
+        firebase.push('gh_events', serialized_params)
+      end
     end
 
     return head(:ok)


### PR DESCRIPTION
allow controllers to check if entry exists and update instead of always pushing new entries to firebase